### PR TITLE
Make cmake build more modular, and work on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+# we require CMake version 2.8.11 (Qt5 recommended)
+cmake_minimum_required(VERSION 2.8.11)
+
+# set project name
+PROJECT(irodsclident)
+
+# set custom cmake module path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
+# set CMake configuration variables and default values
+set(OpenSSL_DIR /usr/local/opt/openssl CACHE PATH "OpenSSL path")
+
+# find Qt CMake packages
+find_package(Qt5 5.4.0 CONFIG REQUIRED Widgets Xml Svg)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  # set correct flags for qt on gcc
+  SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+find_package(iRODS REQUIRED)
+
+include_directories(
+  ${OpenSSL_DIR}/include
+  ${iRODS_INCLUDE_DIRS}
+)
+
+link_directories(
+  ${OpenSSL_DIR}/lib
+  ${iRODS_LIBS_DIRS}
+)
+
+add_subdirectory(src)
+
+install(FILES irodsclient.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications )

--- a/cmake/FindiRODS.cmake
+++ b/cmake/FindiRODS.cmake
@@ -1,0 +1,63 @@
+
+set(iRODS_SRC_DIR /usr/local/irods CACHE PATH "iRODS src directory")
+set(iRODS_PREFIX /usr/ CACHE PATH "iRODS install PATH")
+set(iRODS_Boost boost_1_58_0z CACHE STRING "iRODS Boost version")
+set(iRODS_Jansson jansson-2.7 CACHE STRING "iRODS Jansson version")
+
+
+set(iRODS_INCLUDE_DIRS 	${iRODS_SRC_DIR}/external/${iRODS_Boost}
+  ${iRODS_SRC_DIR}/iRODS/lib/core/include
+  ${iRODS_SRC_DIR}/iRODS/lib/api/include
+  ${iRODS_SRC_DIR}/iRODS/lib/hasher/include
+  ${iRODS_SRC_DIR}/iRODS/server/core/include
+  ${iRODS_SRC_DIR}/iRODS/server/icat/include
+  ${iRODS_SRC_DIR}/iRODS/server/drivers/include
+  ${iRODS_SRC_DIR}/iRODS/server/re/include
+  ${iRODS_SRC_DIR}/iRODS/lib/api/include
+  ${iRODS_SRC_DIR}/iRODS/lib/md5/include
+  ${iRODS_SRC_DIR}/iRODS/lib/sha1/include
+  ${iRODS_SRC_DIR}/iRODS/lib/rbudp/include
+  ${iRODS_PREFIX}/include/irods
+  )
+
+ set(iRODS_LIBS_DIRS ${iRODS_SRC_DIR}/external/${iRODS_Boost}/stage/lib
+  ${iRODS_SRC_DIR}/external/${iRODS_Jansson}/src/.libs
+  ${iRODS_SRC_DIR}/iRODS/lib/core/obj
+  ${iRODS_PREFIX}/lib/irods/externals
+  )
+
+add_library(jansson STATIC IMPORTED)
+set(JANSSON_SRC_LIB "${iRODS_SRC_DIR}/external/${iRODS_Jansson}/src/.libs/libjansson.a")
+if(EXISTS "${JANSSON_SRC_LIB}")
+  set_property(TARGET jansson PROPERTY IMPORTED_LOCATION "${JANSSON_SRC_LIB}")
+else()
+  set_property(TARGET jansson PROPERTY IMPORTED_LOCATION "${iRODS_PREFIX}/lib/irods/externals/libjansson.a")
+endif()
+
+
+
+set(iRODS_LIBS
+  dl
+  pthread
+  irods_client_api
+  irods_client
+  boost_filesystem
+  boost_regex
+  boost_system
+  boost_thread
+  boost_chrono
+  boost_date_time
+  boost_iostreams
+  boost_program_options
+  jansson)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+  # needed for linkage in OSX with iRODS 4.1.8+
+  add_library(client_exec STATIC IMPORTED)
+  set_property(TARGET client_exec PROPERTY IMPORTED_LOCATION ${iRODS_SRC_DIR}/iRODS/lib/client_exec/obj/irods_client_rule_execution_manager_factory.o)
+  list(PREPEND iRODS_LIBS client_exec)
+
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+set(iRODS_FOUND)

--- a/cmake/FindiRODS.cmake
+++ b/cmake/FindiRODS.cmake
@@ -37,8 +37,6 @@ endif()
 
 
 set(iRODS_LIBS
-  dl
-  pthread
   irods_client_api
   irods_client
   boost_filesystem
@@ -56,7 +54,16 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # needed for linkage in OSX with iRODS 4.1.8+
   add_library(client_exec STATIC IMPORTED)
   set_property(TARGET client_exec PROPERTY IMPORTED_LOCATION ${iRODS_SRC_DIR}/iRODS/lib/client_exec/obj/irods_client_rule_execution_manager_factory.o)
-  list(PREPEND iRODS_LIBS client_exec)
+  set(iRODS_LIBS
+    client_exec
+    ${iRODS_LIBS})
+  
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+
+  set(iRODS_LIBS
+    dl
+    pthread
+    ${iRODS_LIBS})
 
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 

--- a/postflight_osx.py
+++ b/postflight_osx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,7 @@
-# we require CMake version 2.8.11 (Qt5 recommended)
-cmake_minimum_required(VERSION 2.8.11)
-
-# set project name
-PROJECT(irodsclident)
 
 # use auto moc feature to build qt meta objects
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-
-# set CMake configuration variables and default values
-set(OpenSSL_DIR /usr/local/opt/openssl CACHE PATH "OpenSSL path")
-set(iRODS_DIR /usr/local/irods CACHE PATH "iRODS PATH")
-set(iRODS_Boost boost_1_58_0z CACHE STRING "iRODS Boost version")
-set(iRODS_Jansson jansson-2.7 CACHE STRING "iRODS Jansson version")
-
-# find Qt CMake packages
-find_package(Qt5 5.4.0 CONFIG REQUIRED Widgets Xml Svg)
 
 # Qt UI compiler files
 file(GLOB UI_FILES *.ui)
@@ -32,77 +18,21 @@ qt5_wrap_ui(UISrcs ${UI_FILES})
 # add Qt resources
 qt5_add_resources(UI_RESOURCES icons.qrc)
 
-include_directories(
-	${OpenSSL_DIR}/include
-	${iRODS_DIR}/external/${iRODS_Boost}
-	${iRODS_DIR}/iRODS/lib/core/include
-	${iRODS_DIR}/iRODS/lib/api/include
-	${iRODS_DIR}/iRODS/lib/hasher/include
-	${iRODS_DIR}/iRODS/server/core/include
-	${iRODS_DIR}/iRODS/server/icat/include
-	${iRODS_DIR}/iRODS/server/drivers/include
-	${iRODS_DIR}/iRODS/server/re/include
-	${iRODS_DIR}/iRODS/lib/api/include
-	${iRODS_DIR}/iRODS/lib/md5/include
-	${iRODS_DIR}/iRODS/lib/sha1/include
-	${iRODS_DIR}/iRODS/lib/rbudp/include
-)
-
-link_directories(
-	${OpenSSL_DIR}/lib 
-	${iRODS_DIR}/external/${iRODS_Boost}/stage/lib
-	${iRODS_DIR}/external/${iRODS_Jansson}/src/.libs
-	${iRODS_DIR}/iRODS/lib/core/obj
-)
-
 # configure target executable
 add_executable(irodsclient MACOSX_BUNDLE ${CXX_FILES} ${UISrcs} ${QT_WRAP} ${UI_RESOURCES})
 
 # include necessary Qt5 modules for linkage 
 qt5_use_modules(irodsclient Core Gui Svg Xml)
 
-add_library(jansson STATIC IMPORTED)
-set_property(TARGET jansson PROPERTY IMPORTED_LOCATION ${iRODS_DIR}/external/${iRODS_Jansson}/src/.libs/libjansson.a)
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-
-# needed for linkage in OSX with iRODS 4.1.8+
-add_library(client_exec STATIC IMPORTED)
-set_property(TARGET client_exec PROPERTY IMPORTED_LOCATION ${iRODS_DIR}/iRODS/lib/client_exec/obj/irods_client_rule_execution_manager_factory.o)
-
 target_link_libraries(
-        irodsclient
-	client_exec
-	RodsAPIs
-        boost_filesystem
-        boost_regex
-	boost_system
-        boost_thread
-        boost_chrono
-	boost_date_time
-        boost_iostreams
-        boost_program_options
-	jansson
-        ssl
-        crypto
-)
+  irodsclient
+  ${iRODS_LIBS}
+  ssl
+  crypto
+  )
 
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+install(TARGETS irodsclient
+  RUNTIME DESTINATION bin)
 
-target_link_libraries(
-	irodsclient
-	RodsAPIs 
-	boost_filesystem
-	boost_regex
-	boost_system
-	boost_thread
-	boost_chrono
-	boost_date_time
-	boost_iostreams
-	boost_program_options
-	jansson
-	ssl
-	crypto
-)
-
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+install(FILES icons/irodsclient.png
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps)

--- a/src/rodsobjmetadata.cpp
+++ b/src/rodsobjmetadata.cpp
@@ -146,10 +146,10 @@ int RodsObjMetadata::addAttribute(std::string attrName, std::string attrValue, s
     mod.arg3 = (char*)attrName.c_str();
     mod.arg4 = (char*)attrValue.c_str();
     mod.arg5 = (char*)attrUnit.c_str();
-    mod.arg6 = "";
-    mod.arg7 = "";
-    mod.arg8 = "";
-    mod.arg9 = "";
+    mod.arg6 = (char*)"";
+    mod.arg7 = (char*)"";
+    mod.arg8 = (char*)"";
+    mod.arg9 = (char*)"";
 
     // execute metadata add thru rods api
     if ((status = rcModAVUMetadata(this->conn->commPtr(), &mod)) < 0)
@@ -199,17 +199,17 @@ int RodsObjMetadata::modifyAttribute(std::string attrName, std::string valueStr,
         mod.arg5 = (char*)unitStr.c_str();
         mod.arg6 = (char*)valueArg.c_str();
         mod.arg7 = (char*)unitArg.c_str();
-        mod.arg8 = "";
-        mod.arg9 = "";
+        mod.arg8 = (char*)"";
+        mod.arg9 = (char*)"";
     }
 
     // otherwise just the value is modified
     else {
         mod.arg5 = (char*)valueArg.c_str();
-        mod.arg6 = "";
-        mod.arg7 = "";
-        mod.arg8 = "";
-        mod.arg9 = "";
+        mod.arg6 = (char*)"";
+        mod.arg7 = (char*)"";
+        mod.arg8 = (char*)"";
+        mod.arg9 = (char*)"";
     }
 
     // execute metadata update thru rods api
@@ -265,10 +265,10 @@ int RodsObjMetadata::removeAttribute(std::string attrName, std::string valueStr,
     remove.arg3 = (char*)attrName.c_str();
     remove.arg4 = (char*)valueStr.c_str();
     remove.arg5 = (char*)unitStr.c_str();
-    remove.arg6 = "";
-    remove.arg7 = "";
-    remove.arg8 = "";
-    remove.arg9 = "";
+    remove.arg6 = (char*)"";
+    remove.arg7 = (char*)"";
+    remove.arg8 = (char*)"";
+    remove.arg9 = (char*)"";
 
     // execute metadata removal thru rods api
     if ((status = rcModAVUMetadata(this->conn->commPtr(), &remove)) < 0)


### PR DESCRIPTION
The cmake files were made more modular and fixed so that things build on linux.

Note that the FindiRODS script needs to be fixed to actually confirm that it is finding irods.

Also fixed some small bugs in other parts of the code.
