### PR TITLE
Change error message to offer solution

### DIFF
--- a/src/rodsconnectthread.cpp
+++ b/src/rodsconnectthread.cpp
@@ -43,7 +43,7 @@ void RodsConnectThread::run()
         // try to authenticate while reporting error trough ui
         if ((status = newConn->login()) < 0)
         {
-            reportError("iRODS login error", newConn->lastErrorMsg().c_str(),
+            reportError("iRODS login error, try using 'iinit' command", newConn->lastErrorMsg().c_str(),
                         newConn->lastError());
 
             delete(newConn);


### PR DESCRIPTION
Hello! In this PR i simply change the error message to let the user know that they can login using 'iinit' command since inexperienced users may expect to be able to login through the GUI.